### PR TITLE
chore: bump to node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,5 +10,5 @@ outputs:
     description: "Version number parsed from GitHub release tag name"
 
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"


### PR DESCRIPTION
closes #1